### PR TITLE
Update include/linker paths of the FOX foxdll VS project

### DIFF
--- a/fox-1.6.58/windows/vcpp/foxdll/foxdll.vcxproj
+++ b/fox-1.6.58/windows/vcpp/foxdll/foxdll.vcxproj
@@ -156,7 +156,7 @@
       <WarningLevel>Level4</WarningLevel>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <AdditionalIncludeDirectories>..\..\..\include;C:\SUMOLibraries\3rdPartyLibs\bzip2-1.0.6;C:\SUMOLibraries\3rdPartyLibs\zlib-1.2.12\include;C:\SUMOLibraries\3rdPartyLibs\jpeg-9c;C:\SUMOLibraries\3rdPartyLibs\libpng-1.6.37\include;C:\SUMOLibraries\3rdPartyLibs\tiff-4.0.9\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\..\include;$(SolutionDir)\..\..\..\\3rdPartyLibs\bzip2-1.1.0\include;$(SolutionDir)\..\..\..\\3rdPartyLibs\zlib-1.3.1\include;$(SolutionDir)\..\..\..\\3rdPartyLibs\jpeg-9f\include;$(SolutionDir)\..\..\..\\3rdPartyLibs\libpng-1.6.44\include;$(SolutionDir)\..\..\..\\3rdPartyLibs\tiff-4.7.0\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;HAVE_ZLIB_H;HAVE_BZ2LIB_H;HAVE_TIFF_H;HAVE_PNG_H;HAVE_JPEG_H;WIN32;_DEBUG;_WINDOWS;UNICODE;_USRDLL;FOXDLL;FOXDLL_EXPORTS;HAVE_GL_H;HAVE_GLU_H;HAVE_VSSCANF;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AssemblerListingLocation>.\Debug\</AssemblerListingLocation>
       <PrecompiledHeaderOutputFile>.\Debug\foxdlld.pch</PrecompiledHeaderOutputFile>
@@ -185,7 +185,7 @@
       <SubSystem>Console</SubSystem>
       <OutputFile>..\..\..\lib\fox-16d.dll</OutputFile>
       <ImportLibrary>.\..\..\..\lib\fox-16d.lib</ImportLibrary>
-      <AdditionalDependencies>C:\SUMOLibraries\3rdPartyLibs\bzip2-1.0.6\lib\libbz2d.lib;C:\SUMOLibraries\3rdPartyLibs\zlib-1.2.12\lib\zlibd.lib;C:\SUMOLibraries\3rdPartyLibs\libpng-1.6.37\lib\libpng16d.lib;C:\SUMOLibraries\3rdPartyLibs\tiff-4.0.9\lib\tiffd.lib;C:\SUMOLibraries\3rdPartyLibs\jpeg-9c\lib\jpeg.lib;opengl32.lib;glu32.lib;comctl32.lib;wsock32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>$(SolutionDir)\..\..\..\3rdPartyLibs\bzip2-1.1.0\lib\bz2.lib;$(SolutionDir)\..\..\..\3rdPartyLibs\zlib-1.3.1\lib\zlibd.lib;$(SolutionDir)\..\..\..\3rdPartyLibs\libpng-1.6.44\lib\libpng16d.lib;$(SolutionDir)\..\..\..\3rdPartyLibs\tiff-4.7.0\lib\tiffd.lib;$(SolutionDir)\..\..\..\3rdPartyLibs\jpeg-9f\lib\jpeg.lib;opengl32.lib;glu32.lib;comctl32.lib;wsock32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ProgramDatabaseFile>..\..\..\lib\fox-16d.pdb</ProgramDatabaseFile>
       <GenerateMapFile>false</GenerateMapFile>
       <AssemblyDebug>true</AssemblyDebug>
@@ -246,7 +246,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <StringPooling>true</StringPooling>
-      <AdditionalIncludeDirectories>..\..\..\include;C:\SUMOLibraries\3rdPartyLibs\bzip2-1.0.6;C:\SUMOLibraries\3rdPartyLibs\zlib-1.2.12\include;C:\SUMOLibraries\3rdPartyLibs\jpeg-9c;C:\SUMOLibraries\3rdPartyLibs\libpng-1.6.37\include;C:\SUMOLibraries\3rdPartyLibs\tiff-4.0.9\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\..\include;$(SolutionDir)\..\..\..\\3rdPartyLibs\bzip2-1.1.0\include;$(SolutionDir)\..\..\..\\3rdPartyLibs\zlib-1.3.1\include;$(SolutionDir)\..\..\..\\3rdPartyLibs\jpeg-9f\include;$(SolutionDir)\..\..\..\\3rdPartyLibs\libpng-1.6.44\include;$(SolutionDir)\..\..\..\\3rdPartyLibs\tiff-4.7.0\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;HAVE_ZLIB_H;HAVE_BZ2LIB_H;HAVE_TIFF_H;HAVE_PNG_H;HAVE_JPEG_H;WIN32;NDEBUG;_WINDOWS;UNICODE;_USRDLL;FOXDLL;FOXDLL_EXPORTS;HAVE_GL_H;HAVE_GLU_H;HAVE_VSSCANF;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AssemblerListingLocation>.\Release\</AssemblerListingLocation>
       <PrecompiledHeaderOutputFile>.\Release\foxdll.pch</PrecompiledHeaderOutputFile>
@@ -274,7 +274,7 @@
       <SubSystem>Console</SubSystem>
       <OutputFile>..\..\..\lib\fox-16.dll</OutputFile>
       <ImportLibrary>.\..\..\..\lib\fox-16.lib</ImportLibrary>
-      <AdditionalDependencies>C:\SUMOLibraries\3rdPartyLibs\bzip2-1.0.6\lib\libbz2.lib;C:\SUMOLibraries\3rdPartyLibs\zlib-1.2.12\lib\zlib.lib;C:\SUMOLibraries\3rdPartyLibs\libpng-1.6.37\lib\libpng16.lib;C:\SUMOLibraries\3rdPartyLibs\tiff-4.0.9\lib\tiff.lib;C:\SUMOLibraries\3rdPartyLibs\jpeg-9c\lib\jpeg.lib;opengl32.lib;glu32.lib;comctl32.lib;wsock32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>$(SolutionDir)\..\..\..\3rdPartyLibs\bzip2-1.1.0\lib\bz2.lib;$(SolutionDir)\..\..\..\3rdPartyLibs\zlib-1.3.1\lib\zlib.lib;$(SolutionDir)\..\..\..\3rdPartyLibs\libpng-1.6.44\lib\libpng16.lib;$(SolutionDir)\..\..\..\3rdPartyLibs\tiff-4.7.0\lib\tiff.lib;$(SolutionDir)\..\..\..\3rdPartyLibs\jpeg-9f\lib\jpeg.lib;opengl32.lib;glu32.lib;comctl32.lib;wsock32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ProgramDatabaseFile>
       </ProgramDatabaseFile>
       <GenerateDebugInformation>false</GenerateDebugInformation>


### PR DESCRIPTION
Replace absolute paths with ones using the VS SolutionDir variable and updating the file paths due to new library versions.